### PR TITLE
コードを直接更新

### DIFF
--- a/src/app/actions/__tests__/formatData.test.tsx
+++ b/src/app/actions/__tests__/formatData.test.tsx
@@ -1,0 +1,142 @@
+import { DiaryType } from '../../../../type/diary';
+import formatTimestampToTime from '../formatData';
+
+describe('formatTimestampToTime関数', () => {
+
+  it('Firestoreのタイムスタンプオブジェクトを「月日(曜日) 時:分」の形式に正しくフォーマットすること', () => {
+    // テストデータの準備
+    const date = new Date('2024-08-03T15:30:00');
+    const seconds = Math.floor(date.getTime() / 1000);
+    const nanoseconds = (date.getTime() % 1000) * 1000000;
+
+    const mockDiaryList = {
+      diaryDate: { seconds, nanoseconds },
+    } as unknown as DiaryType;
+
+    // 関数を実行
+    const result = formatTimestampToTime({ diaryList: mockDiaryList });
+
+    // 期待される結果を検証
+    const expected = '8月3日(土) 15:30';
+    expect(result).toBe(expected);
+  });
+
+  it('異なる日付でも正しくフォーマットされること', () => {
+    // テストデータの準備
+    const date = new Date('2024-12-25T09:15:00');
+    const seconds = Math.floor(date.getTime() / 1000);
+    const nanoseconds = (date.getTime() % 1000) * 1000000;
+
+    const mockDiaryList = {
+      diaryDate: { seconds, nanoseconds },
+    } as unknown as DiaryType;
+
+    // 関数を実行
+    const result = formatTimestampToTime({ diaryList: mockDiaryList });
+
+    // 期待される結果を検証
+    const expected = '12月25日(水) 09:15';
+    expect(result).toBe(expected);
+  });
+
+  it('diaryList.diaryDateが存在しない場合、空文字列を返すこと', () => {
+    // テストデータの準備 (diaryDateプロパティがない)
+    const mockDiaryList = {
+      // diaryDateがない状態をシミュレート
+    } as unknown as DiaryType;
+
+    // 関数を実行
+    const result = formatTimestampToTime({ diaryList: mockDiaryList });
+
+    // 実行結果が空文字列であることを検証
+    expect(result).toBe('');
+  });
+
+  it('diaryList.diaryDateがnullの場合、空文字列を返すこと', () => {
+    // テストデータの準備 (diaryDateがnull)
+    const mockDiaryList = {
+      diaryDate: null,
+    } as unknown as DiaryType;
+
+    // 関数を実行
+    const result = formatTimestampToTime({ diaryList: mockDiaryList });
+
+    // 実行結果が空文字列であることを検証
+    expect(result).toBe('');
+  });
+
+  it('diaryList.diaryDateがundefinedの場合、空文字列を返すこと', () => {
+    // テストデータの準備 (diaryDateがundefined)
+    const mockDiaryList = {
+      diaryDate: undefined,
+    } as unknown as DiaryType;
+
+    // 関数を実行
+    const result = formatTimestampToTime({ diaryList: mockDiaryList });
+
+    // 実行結果が空文字列であることを検証
+    expect(result).toBe('');
+  });
+
+  it('diaryList.diaryDateがタイムスタンプオブジェクトではない場合、空文字列を返すこと', () => {
+    // テストデータの準備 (diaryDateがただの文字列)
+    const mockDiaryList = {
+      diaryDate: '2024-08-03',
+    } as unknown as DiaryType;
+
+    // 関数を実行
+    const result = formatTimestampToTime({ diaryList: mockDiaryList });
+
+    // 実行結果が空文字列であることを検証
+    expect(result).toBe('');
+  });
+
+  it('diaryList.diaryDateがsecondsプロパティを持たないオブジェクトの場合、空文字列を返すこと', () => {
+    // テストデータの準備 (diaryDateが不正なオブジェクト)
+    const mockDiaryList = {
+      diaryDate: { someOtherProperty: 'value' },
+    } as unknown as DiaryType;
+
+    // 関数を実行
+    const result = formatTimestampToTime({ diaryList: mockDiaryList });
+
+    // 実行結果が空文字列であることを検証
+    expect(result).toBe('');
+  });
+
+  it('深夜の時間も正しくフォーマットされること', () => {
+    // テストデータの準備 (深夜0時30分)
+    const date = new Date('2024-08-03T00:30:00');
+    const seconds = Math.floor(date.getTime() / 1000);
+    const nanoseconds = (date.getTime() % 1000) * 1000000;
+
+    const mockDiaryList = {
+      diaryDate: { seconds, nanoseconds },
+    } as unknown as DiaryType;
+
+    // 関数を実行
+    const result = formatTimestampToTime({ diaryList: mockDiaryList });
+
+    // 期待される結果を検証
+    const expected = '8月3日(土) 00:30';
+    expect(result).toBe(expected);
+  });
+
+  it('23時59分の時間も正しくフォーマットされること', () => {
+    // テストデータの準備 (23時59分)
+    const date = new Date('2024-08-03T23:59:00');
+    const seconds = Math.floor(date.getTime() / 1000);
+    const nanoseconds = (date.getTime() % 1000) * 1000000;
+
+    const mockDiaryList = {
+      diaryDate: { seconds, nanoseconds },
+    } as unknown as DiaryType;
+
+    // 関数を実行
+    const result = formatTimestampToTime({ diaryList: mockDiaryList });
+
+    // 期待される結果を検証
+    const expected = '8月3日(土) 23:59';
+    expect(result).toBe(expected);
+  });
+});


### PR DESCRIPTION
Add comprehensive tests for `formatTimestampToTime` and resolve type errors in test mocks.

The `DiaryType` definition expects `Dayjs` for `diaryDate`, but the `formatTimestampToTime` function processes Firestore timestamp objects. The tests were designed to reflect the function's actual input, necessitating `as unknown as DiaryType` for type assertion on mock data.

---
<a href="https://cursor.com/background-agent?bcId=bc-245d0ae1-f728-41af-ae59-97f58cc5cc76">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-245d0ae1-f728-41af-ae59-97f58cc5cc76">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>