### PR TITLE
Investigate jest config exclusion of (tabs)

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,17 @@
+/* eslint-env node */
+module.exports = {
+  preset: 'jest-expo',
+  transformIgnorePatterns: [
+    'node_modules/(?!((jest-)?react-native|@react-native(-community)?)|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|@unimodules/.*|unimodules|sentry-expo|native-base|react-native-svg|firebase|@firebase)',
+  ],
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
+  testMatch: ['**/__tests__/**/*.(ts|tsx|js)', '**/*.(test|spec).(ts|tsx|js)'],
+  collectCoverageFrom: [
+    'src/**/*.{ts,tsx}',
+    '!src/**/*.d.ts',
+    '!src/**/__tests__/**',
+    '!src/app/components/Icon/**',
+    '!src/app/\\(tabs\\)/**',
+  ],
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
+};


### PR DESCRIPTION
Create `jest.config.js` to exclude `src/app/(tabs)` from test coverage reports.

The `(tabs)` directory was not being excluded because parentheses have special meaning in glob patterns. Escaping them (`\\(tabs\\)`) ensures they are treated as literal characters, allowing the directory to be correctly excluded from coverage.

---
<a href="https://cursor.com/background-agent?bcId=bc-660df76b-00c2-48c1-a135-3547142ae2a3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-660df76b-00c2-48c1-a135-3547142ae2a3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>